### PR TITLE
Revive the script: use newer API and getHistory method

### DIFF
--- a/vk_messages_backup.py
+++ b/vk_messages_backup.py
@@ -358,7 +358,10 @@ class vk_dialog:
 
     # assume that all dialogs has different titles
     def dump_filename(self, users_dict):
-        return self.messages[-1].title(users_dict) + '.txt'
+        cname = self.messages[-1].title(users_dict)
+        cname = cname[:100] # max filename is 255, but anyway that should be more than enough
+        # TODO slugify?
+        return cname + '.txt'
 
     def sort(self):
         if self.is_sorted:

--- a/vk_messages_backup.py
+++ b/vk_messages_backup.py
@@ -323,7 +323,7 @@ class vk_dialog:
     def sort(self):
         if self.is_sorted:
             return
-        self.messages.sort(key=lambda msg: msg.raw()['date'])
+        self.messages.sort(key=lambda msg: msg.id())
         self.is_sorted = True
 
     def save(self, storage_dir):


### PR DESCRIPTION
The messages.get api method is pretty much dead... so I switched the script to newer API and made sure everything still works with the messages retrieved from old API. I diffed the json files in my storage, and it looks ok.

Another fix is the `sort` method to sort by id instead of datetime, since sometimes timestamps are equal, so they are not reliable for sorting.

Should fix https://github.com/Totktonada/vk_messages_backup/issues/7